### PR TITLE
feat: extract g-force resistance from flight suit clothing params

### DIFF
--- a/src/Formats/ScUnpacked/GForceResistance.php
+++ b/src/Formats/ScUnpacked/GForceResistance.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Octfx\ScDataDumper\Formats\ScUnpacked;
+
+use Octfx\ScDataDumper\Formats\BaseFormat;
+
+final class GForceResistance extends BaseFormat
+{
+    protected ?string $elementKey = 'Components/SCItemClothingParams/Flight';
+
+    public function toArray(): ?array
+    {
+        if (! $this->canTransform()) {
+            return null;
+        }
+
+        $flight = $this->get();
+
+        return [
+            'Value' => $flight->get('@gForceResistance'),
+        ];
+    }
+}

--- a/src/Formats/ScUnpacked/Item.php
+++ b/src/Formats/ScUnpacked/Item.php
@@ -155,6 +155,7 @@ final class Item extends BaseFormat
                 'SuitArmor' => new SuitArmor($this->item),
                 'TemperatureResistance' => new TemperatureResistance($this->item),
                 'RadiationResistance' => new RadiationResistance($this->item),
+                'GForceResistance' => new GForceResistance($this->item),
                 'Thruster' => new Thruster($this->item),
                 'TractorBeam' => new TractorBeam($this->item),
                 'Turret' => new Turret($this->item),


### PR DESCRIPTION
Adds a `GForceResistance` format class that reads `SCItemClothingParams/Flight@gForceResistance` and registers it in `Item::toArray()` alongside the existing `TemperatureResistance` and `RadiationResistance` suit stat classes.