### PR TITLE
fix: return null from Radar::toArray when signatureDetection is empty

### DIFF
--- a/src/Formats/ScUnpacked/Radar.php
+++ b/src/Formats/ScUnpacked/Radar.php
@@ -41,6 +41,10 @@ final class Radar extends BaseFormat
             $signatureList[] = $sig;
         }
 
+        if (empty($signatureList)) {
+            return null;
+        }
+
         $sensitivity = $this->extractSignatureColumns($signatureList, 'sensitivity');
         $piercing = $this->extractSignatureColumns($signatureList, 'piercing');
 


### PR DESCRIPTION
Without this guard an item that has `SCItemRadarComponentParams` but no `signatureDetection` children produces a radar record with all-null `Sensitivity`/`Piercing` columns instead of returning `null`. One-line fix.