### PR TITLE
fix: route TractorBeam items to ship-items.json

### DIFF
--- a/src/Commands/LoadItems.php
+++ b/src/Commands/LoadItems.php
@@ -91,7 +91,10 @@ class LoadItems extends AbstractDataCommand
                 }
                 fwrite($fpsHandle, $encodedItem);
                 $fpsFirst = false;
-            } elseif (is_string($classification) && str_starts_with($classification, 'Ship.')) {
+            } elseif (
+                (is_string($classification) && str_starts_with($classification, 'Ship.'))
+                || ($stdItem['type'] ?? null) === 'TractorBeam'
+            ) {
                 if (! $shipFirst) {
                     fwrite($shipHandle, ",\n");
                 }


### PR DESCRIPTION
Ship-mounted tractor beams (`GRIN_TractorBeam_S*`, `ARGO_ATLS_TractorBeam_S*`) have `type=TractorBeam` but no `Ship.*` classification prefix, so they fall through to the general `items.json` index instead of `ship-items.json`.

FPS tractor beam attachments are unaffected — they carry an `FPS.*` classification and are caught by the earlier branch before reaching this condition.